### PR TITLE
Implementing join functions

### DIFF
--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -626,13 +626,13 @@ macro arrange(df, exprs...)
   return_val
 end
 
-function left_join(df1, df2; by=nothing)
+function left_join(df1::AbstractDataFrame, df2::AbstractDataFrame; by=nothing)
   # left join two DataFrames
   # This function takes a string or a vector of strings for `on` argument
   # First step, join two data frames using one column
   # Second step, consider when on is not specified, how to autojoin
   # Third step, take an expression
-  if typeof(by) == Expr
+  if by isa Expr
     str_by = replace(string(by), r"[\[\]]" => "")
     str_by_vec = split(str_by, ",")
 
@@ -653,7 +653,7 @@ function left_join(df1, df2; by=nothing)
         by = names(df1)[common_cols]
       end
     else
-      if typeof(by) == String
+      if by isa String
         by = push!([], by)
       end
     end

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -223,7 +223,7 @@ function parse_join_by(tidy_expr::Union{Expr,Vector{Expr}})
   vec_call = []
 
   MacroTools.postwalk(tidy_expr) do x
-    if @capture(x, l_Symbol_ = r_Symbol_)
+    if @capture(x, l_Symbol_ == r_Symbol_)
       push!(vec_call, Pair(l_Symbol, r_Symbol))
     elseif x isa String
       push!(vec_call, Meta.parse(x))
@@ -656,6 +656,6 @@ df4 = DataFrame(zid=[2, 3, 4], z=[4, 5, 6])
 df5 = DataFrame(zid=[1, 2, 4], fid=[10, 11, 12], z=[4, 5, 6])
 
 @left_join(df1, df3, "id")
-@left_join(df1, df2, ["id", "pid"])
-@left_join(df1, df4, id = zid)
-@left_join(df1, df5, [id = zid, pid = fid])
+@left_join(df1, df2, ("id", "pid"))
+@left_join(df1, df4, id == zid)
+@left_join(df1, df5, (id == zid, pid == fid))

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -9,7 +9,7 @@ using Reexport
 @reexport using Chain
 @reexport using Statistics
 
-export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, across, desc, left_join
+export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, @left_join, across, desc
 
 """
     across(variable[s], function[s])


### PR DESCRIPTION
I use this draft PR for self-learning purposes. Do NOT merge this PR.

Implementing join functions, starting with `left_join(df1, df2, by)`. The goal is listed by the following:

- [ ] if `by` is passed nothing, the function will find common columns to join
- [x] `by` can be passed with a single string indicating variable name
- [x] `by` can be passed with a vector of strings indication multi-columns joining
- [x] similar to `dplyr` in R, `by` can take expressions like `(id == pid)` to match columns with different names
- [x] Wrap the function into a macro
