### PR TITLE
Add left_join macros

### DIFF
--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -705,3 +705,4 @@ macro join_by(by::Expr)
   end
 end
 
+end

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -646,11 +646,17 @@ julia> df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])
 
 julia> @left_join(df1, df2, "id")
 
+julia> @left_join(df1, df2, id)
+
 julia> @left_join(df1, df2)
 
 julia> @left_join(df1, df2, @join_by("id"))
 
+julia> @left_join(df1, df2, @join_by(id))
+
 julia> @left_join(df1, df3, @join_by("id" == "employee_id"))
+
+julia> @left_join(df1, df3, @join_by(id == employee_id))
 ```
 """
 
@@ -662,7 +668,7 @@ end
 
 macro left_join(df1, df2, by::Symbol)
   quote  
-    leftjoin($(esc(df1)), $(esc(df2)), on = $(esc(by)))
+    leftjoin($(esc(df1)), $(esc(df2)), on = Symbol($(string(by))))
   end
 end
 
@@ -688,15 +694,21 @@ macro left_join(df1, df2)
   end
 end
 
+function str_to_pair(by::String)
+  expr = Meta.parse(by)
+  return(Symbol(expr.args[2]) => Symbol(expr.args[3]))
+end
+
 macro join_by(by::String)
   quote
     Symbol.($(esc(by)))
   end
 end
 
-function str_to_pair(by::String)
-  expr = Meta.parse(by)
-  return(Symbol(expr.args[2]) => Symbol(expr.args[3]))
+macro join_by(by::Symbol)
+  quote
+    Symbol($(string(by)))
+  end
 end
 
 macro join_by(by::Expr)

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -650,13 +650,13 @@ julia> @left_join(df1, df2, id)
 
 julia> @left_join(df1, df2)
 
-julia> @left_join(df1, df2, @join_by("id"))
+julia> @left_join(df1, df2, join_by("id"))
 
-julia> @left_join(df1, df2, @join_by(id))
+julia> @left_join(df1, df2, join_by(id))
 
-julia> @left_join(df1, df3, @join_by("id" == "employee_id"))
+julia> @left_join(df1, df3, join_by("id" == "employee_id"))
 
-julia> @left_join(df1, df3, @join_by(id == employee_id))
+julia> @left_join(df1, df3, join_by(id == employee_id))
 ```
 """
 

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -9,7 +9,7 @@ using Reexport
 @reexport using Chain
 @reexport using Statistics
 
-export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, across, desc
+export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, @left_join, across, desc
 
 """
     across(variable[s], function[s])

--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -9,7 +9,7 @@ using Reexport
 @reexport using Chain
 @reexport using Statistics
 
-export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, @left_join, across, desc
+export @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @slice, @arrange, @left_join, @join_by, across, desc
 
 """
     across(variable[s], function[s])
@@ -643,8 +643,8 @@ julia> using DataFrames
 julia> df1 = DataFrame(id = [1,2,3], val1 = ["A", "B", "C"])
 julia> df2 = DataFrame(id = [1,2,3], val2 = ["D", "E", "F"])
 julia> df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])
-  
-julia> @left_join(df1, df2, :id)
+
+julia> @left_join(df1, df2, "id")
 
 julia> @left_join(df1, df2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,10 +36,18 @@ end
   df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])  
 
   @test isequal(@left_join(df1, df2, "id"), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, id), leftjoin(df1, df2, on = :id))
+
   @test isequal(@left_join(df1, df2), leftjoin(df1, df2, on = :id))
+
   @test isequal(@left_join(df1, df2, @join_by("id")), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, @join_by(id)), leftjoin(df1, df2, on = :id))
+
   @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
                 @left_join(df1, df3, @join_by("id" == "employee_id")))
+  @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
+                @left_join(df1, df3, @join_by(id == employee_id)))
+
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,13 +40,13 @@ end
 
   @test isequal(@left_join(df1, df2), leftjoin(df1, df2, on = :id))
 
-  @test isequal(@left_join(df1, df2, @join_by("id")), leftjoin(df1, df2, on = :id))
-  @test isequal(@left_join(df1, df2, @join_by(id)), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, join_by("id")), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, join_by(id)), leftjoin(df1, df2, on = :id))
 
   @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
-                @left_join(df1, df3, @join_by("id" == "employee_id")))
+                @left_join(df1, df3, join_by("id" == "employee_id")))
   @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
-                @left_join(df1, df3, @join_by(id == employee_id)))
+                @left_join(df1, df3, join_by(id == employee_id)))
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
   df2 = DataFrame(id = [1,2,3], val2 = ["D", "E", "F"])
   df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])  
 
-  @test isequal(@left_join(df1, df2, :id), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, "id"), leftjoin(df1, df2, on = :id))
   @test isequal(@left_join(df1, df2), leftjoin(df1, df2, on = :id))
   @test isequal(@left_join(df1, df2, @join_by("id")), leftjoin(df1, df2, on = :id))
   @test isequal(leftjoin(df1, df3, on = :id => :employee_id),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,20 +33,20 @@ end
 @testset "left_join" begin
   df1 = DataFrame(id = [1,2,3], val1 = ["A", "B", "C"])
   df2 = DataFrame(id = [1,2,3], val2 = ["D", "E", "F"])
-  df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])  
+  df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"]) 
+  
+  df12 = leftjoin(df1, df2, on = :id)
 
-  @test isequal(@left_join(df1, df2, "id"), leftjoin(df1, df2, on = :id))
-  @test isequal(@left_join(df1, df2, id), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, "id"), df12)
+  @test isequal(@left_join(df1, df2, id), df12)
+  @test isequal(@left_join(df1, df2), df12)
+  @test isequal(@left_join(df1, df2, join_by("id")), df12)
+  @test isequal(@left_join(df1, df2, join_by(id)), df12)
 
-  @test isequal(@left_join(df1, df2), leftjoin(df1, df2, on = :id))
+  df13 = leftjoin(df1, df3, on = :id => :employee_id)
 
-  @test isequal(@left_join(df1, df2, join_by("id")), leftjoin(df1, df2, on = :id))
-  @test isequal(@left_join(df1, df2, join_by(id)), leftjoin(df1, df2, on = :id))
-
-  @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
-                @left_join(df1, df3, join_by("id" == "employee_id")))
-  @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
-                @left_join(df1, df3, join_by(id == employee_id)))
+  @test isequal(@left_join(df1, df3, join_by("id" == "employee_id")), df13)
+  @test isequal(@left_join(df1, df3, join_by(id == employee_id)), df13)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,18 @@ end
 
 end
 
+@testset "left_join" begin
+  df1 = DataFrame(id = [1,2,3], val1 = ["A", "B", "C"])
+  df2 = DataFrame(id = [1,2,3], val2 = ["D", "E", "F"])
+  df3 = DataFrame(employee_id = [1,2,3], val3 = ["G", "H", "I"])  
+
+  @test isequal(@left_join(df1, df2, :id), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2), leftjoin(df1, df2, on = :id))
+  @test isequal(@left_join(df1, df2, @join_by("id")), leftjoin(df1, df2, on = :id))
+  @test isequal(leftjoin(df1, df3, on = :id => :employee_id),
+                @left_join(df1, df3, @join_by("id" == "employee_id")))
+end
+
 end
 
 #


### PR DESCRIPTION
This adds a first pass at left_join macros to enable the behaviour mentioned in https://github.com/kdpsingh/Tidier.jl/issues/11
along with unit tests that verify that the macros work as expected for these initial cases. Exports two new macros, `@left_join` and `@join_by` - if we want to be able to use syntax like `join_by("id1" == "id2")` I think join_by needs to be a macro (or at least, I don't know how to make it work as a function).

Still to be added/tested:
- Other joins
- Multi-column joins
  