### PR TITLE
Use `@chain` macro inside of package to improve readability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ meta-packages in Julia:
     calculate the mean value of a symbol. To handle this using idiomatic
     Julia, `DataFrames.jl` introduces a mini-language that relies heavily
     on the creation of anonymous functions, with explicit directional
-    assignment using a `source => function => destination` syntax. While
-    this is quite elegant, it can be quite verbose. `Tidier.jl` aims to
+    pairs syntax using a `source => function => destination` syntax. While
+    this is quite elegant, it can be verbose. `Tidier.jl` aims to
     reduce this complexity by exposing an R-like syntax, which is then
     converted into valid `DataFrames.jl` code. The reason that
     *tidy expressions* are considered valid by Julia in `Tidier.jl` is

--- a/docs/examples/UserGuide/joins.jl
+++ b/docs/examples/UserGuide/joins.jl
@@ -1,6 +1,6 @@
 # One really nice thing about the R `tidyverse` implementation of joins is that they support natural joins. If you don't specify which columns to join on, these column names are inferred from the overlapping columns. While you can override this behavior by specifying which columns to join on, it's convenient that this is not strictly required. We have adopted a similar approach to joins in `Tidier.jl`.
 
-# Here, we will *only* show exmples of natural joins. For additional ways to join, take a look at the examples in the [Reference](https://kdpsingh.github.io/Tidier.jl/dev/reference/).
+# Here, we will *only* show examples of natural joins. For additional ways to join, take a look at the examples in the [Reference](https://kdpsingh.github.io/Tidier.jl/dev/reference/).
 
 using Tidier
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,8 +26,8 @@ meta-packages in Julia:
     calculate the mean value of a symbol. To handle this using idiomatic
     Julia, `DataFrames.jl` introduces a mini-language that relies heavily
     on the creation of anonymous functions, with explicit directional
-    assignment using a `source => function => destination` syntax. While
-    this is quite elegant, it can be quite verbose. `Tidier.jl` aims to
+    pairs syntax using a `source => function => destination` syntax. While
+    this is quite elegant, it can be verbose. `Tidier.jl` aims to
     reduce this complexity by exposing an R-like syntax, which is then
     converted into valid `DataFrames.jl` code. The reason that
     *tidy expressions* are considered valid by Julia in `Tidier.jl` is


### PR DESCRIPTION
`@chain` is used internally anytime multiple data operations need to be performed on a data frame. This improves readability and makes errors easier to spot.

Minor edits to docs.