### PR TITLE
Refactor pivot code to better support options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Added support for negative selection helper functions (e.g., `-contains("a")`)
 - Added support for negative selection using `!` (e.g., `!a`, `!(a:b)`, `!contains("a")`)
+- In `@pivot_longer()`, the `names_to` and `values_to` arguments now also support strings (in addition to bare unquoted names).
+- In `@pivot_wider()`, the `names_from` and `values_from` arguments now also support strings (in addition to bare unquoted names).
 
 ## v0.5.0 - 2023-03-10
 
@@ -15,7 +17,7 @@
 
 ## v0.4.1 - 2023-03-05
 
-- In addition `in` being auto-vectorized as before, the second argument is automatically wrapped inside of `Ref(Set(arg2))` if not already done to ensure that it is evaluated correctly and fast. See: https://bkamins.github.io/julialang/2023/02/10/in.html for details. This same behavior is also implemented for `∈` and `∉`.
+- In addition to `in` being auto-vectorized as before, the second argument is automatically wrapped inside of `Ref(Set(arg2))` if not already done to ensure that it is evaluated correctly and fast. See: https://bkamins.github.io/julialang/2023/02/10/in.html for details. This same behavior is also implemented for `∈` and `∉`.
 - Added documentation and docstrings for new `in` behavior with `@filter()` and `@mutate()`.
 - Improved interpolation to support values and not just column names. Note: there is a change of behavior now for strings, which are treated as values and not as column names. Updated examples in the documentation webpage for interpolation.
 - Bug fix: Re-exported `Cols()` because this is required for interpolated columns inside of `across()`. Previously, this was passing tests because `using RDatasets` was exporting `Cols()`.

--- a/docs/examples/UserGuide/pivots.jl
+++ b/docs/examples/UserGuide/pivots.jl
@@ -16,7 +16,9 @@ df_long = DataFrame(id = [1, 1, 2, 2],
 
 @pivot_wider(df_long, names_from = variable, values_from = value)
 
-# In `@pivot_wider()`, both the `names_from` and `values_from` arguments are required.
+# In `@pivot_wider()`, both the `names_from` and `values_from` arguments are required. `@pivot_wider()` also supports string values for the `names_from` and `values_from` arguments.
+
+@pivot_wider(df_long, names_from = "variable", values_from = "value")
 
 # ## `@pivot_longer()`
 
@@ -34,6 +36,12 @@ df_wide = DataFrame(id = [1, 2], A = [1, 3], B = [2, 4])
 
 @pivot_longer(df_wide, -id)
 
-# In this example, we set the `names_to` and `values_to` arguments. Either argument can be left out and will revert to the default value. The `names_to` and `values_to` arguments must be bare unquoted variable names. Strings containing variable names are not yet supported.
+# In this example, we set the `names_to` and `values_to` arguments. Either argument can be left out and will revert to the default value. The `names_to` and `values_to` arguments can be provided as strings or as bare unquoted variable names.
+
+# Here is an example with `names_to` and `values_to` containing strings:
+
+@pivot_longer(df_wide, A:B, names_to = "letter", values_to = "number")
+
+# And here is an example with `names_to` and `values_to` containing bare unquoted variables:
 
 @pivot_longer(df_wide, A:B, names_to = letter, values_to = number)

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -987,6 +987,14 @@ julia> @pivot_wider(df_long, names_from = variable, values_from = value)
    1 │     1       1       2
    2 │     2       3       4
 
+julia> @pivot_wider(df_long, names_from = "variable", values_from = "value")
+2×3 DataFrame
+ Row │ id     A       B      
+     │ Int64  Int64?  Int64?
+─────┼───────────────────────
+   1 │     1       1       2
+   2 │     2       3       4
+
 julia> @pivot_wider(df_long_missing, names_from = variable, values_from = value, values_fill = 0)
 2×3 DataFrame
  Row │ id     A      B     
@@ -1033,6 +1041,16 @@ julia> @pivot_longer(df_wide, -id)
    3 │     1  B             2
    4 │     2  B             4
 
+julia> @pivot_longer(df_wide, A:B, names_to = "letter", values_to = "number")
+4×3 DataFrame
+ Row │ id     letter  number 
+     │ Int64  String  Int64
+─────┼───────────────────────
+   1 │     1  A            1
+   2 │     2  A            3
+   3 │     1  B            2
+   4 │     2  B            4
+
 julia> @pivot_longer(df_wide, A:B, names_to = letter, values_to = number)
 4×3 DataFrame
  Row │ id     letter  number 
@@ -1043,7 +1061,7 @@ julia> @pivot_longer(df_wide, A:B, names_to = letter, values_to = number)
    3 │     1  B            2
    4 │     2  B            4
 
-julia> @pivot_longer(df_wide, A:B, names_to = letter)
+julia> @pivot_longer(df_wide, A:B, names_to = "letter")
 4×3 DataFrame
  Row │ id     letter  value 
      │ Int64  String  Int64

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -905,6 +905,10 @@ julia> df_long = DataFrame(id = [1, 1, 2, 2],
                            variable = ["A", "B", "A", "B"],
                            value = [1, 2, 3, 4]);
 
+julia> df_long_missing = DataFrame(id = [1, 1, 2],
+                           variable = ["A", "B", "B"],
+                           value = [1, 2, 4]);
+
 julia> @pivot_wider(df_long, names_from = variable, values_from = value)
 2×3 DataFrame
  Row │ id     A       B      
@@ -912,6 +916,14 @@ julia> @pivot_wider(df_long, names_from = variable, values_from = value)
 ─────┼───────────────────────
    1 │     1       1       2
    2 │     2       3       4
+
+julia> @pivot_wider(df_long_missing, names_from = variable, values_from = value, values_fill = 0)
+2×3 DataFrame
+ Row │ id     A      B     
+     │ Int64  Int64  Int64
+─────┼─────────────────────
+   1 │     1      1      2
+   2 │     2      0      4
 ```
 """
 

--- a/src/pivots.jl
+++ b/src/pivots.jl
@@ -44,12 +44,12 @@ macro pivot_longer(df, exprs...)
 
     # if names_to was specified, pass that argument to variable_name
     if haskey(expr_dict, QuoteNode(:names_to))
-        arg_dict[:variable_name] = eval(expr_dict[QuoteNode(:names_to)])
+        arg_dict[:variable_name] = (expr_dict[QuoteNode(:names_to)]).value
     end
 
     # if values_to was specified, pass that argument to value_name
     if haskey(expr_dict, QuoteNode(:values_to))
-        arg_dict[:value_name] = eval(expr_dict[QuoteNode(:values_to)])
+        arg_dict[:value_name] = (expr_dict[QuoteNode(:values_to)]).value
     end
 
     # splat any specified arguments in to stack()

--- a/src/pivots.jl
+++ b/src/pivots.jl
@@ -7,10 +7,19 @@ macro pivot_wider(df, exprs...)
     tidy_exprs = parse_pivot_args.(tidy_exprs)
     expr_dict = Dict(x.args[2] => x.args[3] for x in tidy_exprs)
 
+    # we need to define a dictionary 
+    # to hold arguments in the format expected by unstack()
+    arg_dict = Dict{Symbol, Any}()
+
+    if haskey(expr_dict, QuoteNode(:values_fill))
+        arg_dict[:fill] = String(eval(expr_dict[QuoteNode(:values_fill)]))
+    end
+
     df_expr = quote
         unstack(DataFrame($(esc(df))), 
             $(expr_dict[QuoteNode(:names_from)]),
-            $(expr_dict[QuoteNode(:values_from)]))
+            $(expr_dict[QuoteNode(:values_from)]);
+            $(arg_dict)...)
     end
 
     if code[]
@@ -24,33 +33,28 @@ end
 $docstring_pivot_longer
 """
 macro pivot_longer(df, exprs...)
+    # take the expressions and return arg => value dictionary 
     tidy_exprs = parse_interpolation.(exprs)
     tidy_exprs = parse_pivot_args.(tidy_exprs)
     expr_dict = Dict(x.args[2] => x.args[3] for x in tidy_exprs)
 
-    if !haskey(expr_dict, QuoteNode(:(names_to))) && !haskey(expr_dict, QuoteNode(:(values_to)))
-        df_expr = quote
-            stack(DataFrame($(esc(df))), $(expr_dict[QuoteNode(:cols)]))
-        end
-    elseif (haskey(expr_dict, QuoteNode(:(names_to))) && haskey(expr_dict, QuoteNode(:(values_to))))
-        df_expr = quote
-            stack(DataFrame($(esc(df))), 
-                $(expr_dict[QuoteNode(:cols)]),
-                variable_name = $(expr_dict[QuoteNode(:names_to)]),
-                value_name = $(expr_dict[QuoteNode(:values_to)]))
-        end
-    elseif haskey(expr_dict, QuoteNode(:(names_to)))
-        df_expr = quote
-            stack(DataFrame($(esc(df))), 
-                $(expr_dict[QuoteNode(:cols)]),
-                variable_name = $(expr_dict[QuoteNode(:names_to)]))
-        end
-    elseif haskey(expr_dict, QuoteNode(:(values_to)))
-        df_expr = quote
-            stack(DataFrame($(esc(df))), 
-                $(expr_dict[QuoteNode(:cols)]),
-                value_name = $(expr_dict[QuoteNode(:values_to)]))
-        end
+    # we need to define a dictionary 
+    # to hold arguments in the format expected by stack()
+    arg_dict = Dict{Symbol, Any}()
+
+    # if names_to was specified, pass that argument to variable_name
+    if haskey(expr_dict, QuoteNode(:names_to))
+        arg_dict[:variable_name] = eval(expr_dict[QuoteNode(:names_to)])
+    end
+
+    # if values_to was specified, pass that argument to value_name
+    if haskey(expr_dict, QuoteNode(:values_to))
+        arg_dict[:value_name] = eval(expr_dict[QuoteNode(:values_to)])
+    end
+
+    # splat any specified arguments in to stack()
+    df_expr = quote
+        stack(DataFrame($(esc(df))), $(expr_dict[QuoteNode(:cols)]); $(arg_dict)...)
     end
 
     if code[]
@@ -59,3 +63,4 @@ macro pivot_longer(df, exprs...)
     
     return df_expr
 end
+

--- a/src/pivots.jl
+++ b/src/pivots.jl
@@ -12,7 +12,7 @@ macro pivot_wider(df, exprs...)
     arg_dict = Dict{Symbol, Any}()
 
     if haskey(expr_dict, QuoteNode(:values_fill))
-        arg_dict[:fill] = String(eval(expr_dict[QuoteNode(:values_fill)]))
+        arg_dict[:fill] = eval(expr_dict[QuoteNode(:values_fill)])
     end
 
     df_expr = quote


### PR DESCRIPTION
This refactors the pivot code to use the original intended design - creates a dictionary and passes it to stack or unstack. This should allow support for additional options to be added much more easily